### PR TITLE
Improve backend linting.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint
-        uses: github/super-linter@v3
+        uses: github/super-linter/slim@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BRANCH: main
-          VALIDATE_PYTHON_FLAKE8: true
+          DEFAULT_BRANCH: master
+          VALIDATE_ALL_CODEBASE: false
           VALIDATE_PYTHON_BLACK: true
+          VALIDATE_PYTHON_FLAKE8: true
 
 
   frontend-lint:

--- a/.github/workflows/linters/.python-black
+++ b/.github/workflows/linters/.python-black
@@ -1,0 +1,2 @@
+[tool.black]
+line-length=120


### PR DESCRIPTION
Updated the linting image to `v4` which also comes with a `slim` variant to improve not only download speed but initial runtime.

Added the black rule for line length to be 120.