### PR TITLE
fix docker setup to use layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next

--- a/README.md
+++ b/README.md
@@ -116,5 +116,13 @@ After installing the dependancies and copying/symlinking the config, you can bri
 If using the default port, it'd look like `yarn run start --port 4340`.
 
 
+## Docker Installation
+
+To run docker, copy the configuration as noted above to the proper places, but additionally, copy (or symlink) ``config.json`` to ``mystbin/frontend/config.json``.
+
+Then you can proceed as normal with running ``docker compose up``.
+
 ## Other things
 This guide does not cover using a reverse proxy, if you need assistance with that, google "reverse proxy nginx tutorial".
+
+For docker, this guide assumes you have docker compose installed. If you do not, you will need it installed.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   api:
     build: mystbin/backend
     ports:
-      - 5557:9000/tcp
+      - 127.0.0.1:5557:9000/tcp
     volumes:
       - ./mystbin/database/schema.sql:/etc/schema.sql:ro
       - ./config.json:/usr/src/app/config.json:ro
@@ -16,8 +16,6 @@ services:
 
   database:
     image: postgres:14-alpine
-    ports:
-      - 5558:5432
     container_name: "mystbin-database"
     volumes:
       - postgresdata:/var/lib/postgresql/data/pgdata
@@ -33,7 +31,7 @@ services:
     volumes:
       - ./config.json:/app/config.json:ro
     ports:
-      - 5559:3000
+      - 127.0.0.1:5559:3000
     container_name: "mystbin-frontend"
     build: ./mystbin/frontend
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   api:
     build: mystbin/backend
     ports:
-      - 127.0.0.1:5557:9000/tcp
+      - 5557:9000/tcp
     volumes:
       - ./mystbin/database/schema.sql:/etc/schema.sql:ro
       - ./config.json:/usr/src/app/config.json:ro
@@ -17,7 +17,7 @@ services:
   database:
     image: postgres:14-alpine
     ports:
-      - 127.0.0.1:5558:5432
+      - 5558:5432
     container_name: "mystbin-database"
     volumes:
       - postgresdata:/var/lib/postgresql/data/pgdata
@@ -33,7 +33,7 @@ services:
     volumes:
       - ./config.json:/app/config.json:ro
     ports:
-      - 127.0.0.1:5559:3000
+      - 5559:3000
     container_name: "mystbin-frontend"
     build: ./mystbin/frontend
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,9 +11,6 @@ services:
     environment:
       DEBUG: "${DEBUG}"
     container_name: "mystbin-api"
-    networks:
-      main:
-        ipv4_address: 172.25.0.11
     depends_on:
       - database
 
@@ -31,14 +28,9 @@ services:
       POSTGRES_USER: "${POSTGRES_USER}"
       POSTGRES_HOST_AUTH_METHOD: "md5"
       PGDATA: /var/lib/postgresql/data/pgdata
-    networks:
-      main:
-        ipv4_address: 172.25.0.12
 
   frontend:
-    image: node:latest
     volumes:
-      - node_modules:/app/node_modules
       - ./config.json:/app/config.json:ro
     ports:
       - 127.0.0.1:5559:3000
@@ -46,18 +38,7 @@ services:
     build: ./mystbin/frontend
     depends_on:
       - api
-    networks:
-      main:
-        ipv4_address: 172.25.0.13
 
 volumes:
   postgresdata:
   node_modules:
-
-
-networks:
-  main:
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.25.0.0/16

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,4 +41,3 @@ services:
 
 volumes:
   postgresdata:
-  node_modules:

--- a/mystbin/frontend/Dockerfile
+++ b/mystbin/frontend/Dockerfile
@@ -1,11 +1,16 @@
-FROM node:latest
+FROM node:16-alpine as dep
 
-RUN mkdir -p /app
+# avoid rebuilding the node modules on every single file change, instead only when our deps change.
 WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
 
-COPY . /app
+FROM node:16-alpine AS builder
 
-RUN yarn install --production
+ENV NODE_ENV=production
+WORKDIR /app
+COPY . .
+COPY --from=dep /app/node_modules ./node_modules
+RUN yarn build
 
-ENV NODE_OPTIONS="--openssl-legacy-provider"
-CMD ["yarn", "run", "launch"]
+CMD ["./node_modules/.bin/next", "start"]

--- a/mystbin/frontend/Dockerfile
+++ b/mystbin/frontend/Dockerfile
@@ -13,4 +13,12 @@ COPY . .
 COPY --from=dep /app/node_modules ./node_modules
 RUN yarn build
 
-CMD ["./node_modules/.bin/next", "start"]
+FROM node:16-alpine AS runner
+
+ENV NODE_ENV=production
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+
+CMD [ "yarn", "run", "start"]


### PR DESCRIPTION
This changes the docker setup of the frontend to use layers. The advantage to this is that layers are cached, so as long as the dependency files (package,json & yarn.lock) are not changed, they will not cause a rebuild of the node modules. This gives a huge speedup of subsequent builds using docker.