### PR TITLE
Implement CI for MystBin

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -1,0 +1,80 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Create and publish a Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  cancel-in-progress: true
+  group: ci-${{ github.ref }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    env:
+      GIT_SHA: ${GITHUB_SHA::7}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@master
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@master
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Generate lowername image
+        id: image-name
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "${GITHUB_OUTPUT}"
+        env:
+          IMAGE_NAME: '${{ env.IMAGE_NAME }}'
+
+      - name: Get short SHA
+        id: slug
+        run: echo "GIT_SHORT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME_LC }}:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
+            ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME_LC }}:latest
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["Create and publish a Docker image"]
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    name: Deploy bot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remote deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd ~/mystbin
+            git reset --hard HEAD || true
+            git pull origin main
+            docker compose --profile redis pull
+            docker compose --profile redis up --build -d mystbin
+          username: ${{ secrets.SSH_USER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
-LABEL org.opencontainers.image.source=https://github.com/pythonistaguild/mystbin-backend
-LABEL org.opencontainers.image.description="Mystbin's Python Backend"
+LABEL org.opencontainers.image.source=https://github.com/pythonistaguild/mystbin
+LABEL org.opencontainers.image.description="Container for running MystB.in"
 LABEL org.opencontainers.image.licenses=GPLv3
 
 RUN mkdir -p /etc/apt/keyrings \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   mystbin:
-    image: ghcr.io/pythonista-guild/mystbin
+    image: ghcr.io/pythonistaguild/mystbin
     container_name: mystbin
     ports:
       - 8181:8181

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,6 @@
 services:
   mystbin:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/pythonista-guild/mystbin
     container_name: mystbin
     ports:
       - 8181:8181


### PR DESCRIPTION
## Description
This PR adds capability for CI for MystBin using GitHub actions.

The steps it follows are:-

1) A push to main will build a Docker image of the MystBin software and publish this to GHCR under the PythonistaGuild organization. This will be a public image so that anyone may use it.
2) On a successful build and publish of this image, it will execute a deployment action and deploy this newly built image to the current host of MystBin.
2a) This deployment stage will only restart the mystbin service, not the pg database nor the redis cache.

This is currently not very testable due to the limitations of GitHub actions and may require subsequent PRs. In such cases I will use my break-glass privileges to squash and force push any fixes I must do.

Non-goals of this PR:-
- HADR / Replication of the database for a staging environment.
  - I plan to tackle this at a later date.

## Checklist

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
