### PR TITLE
Make sure newly created pastes are displayed as "now".

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -100,8 +100,10 @@ def validate_discord_token(token: str) -> bool:
     else:
         return True
 
+
 def pluralize(count: int, singular: str) -> str:
     return singular if count == 1 else singular + "s"
+
 
 def natural_time(
     td: datetime.timedelta,
@@ -114,8 +116,13 @@ def natural_time(
     then = now - td
     future = then > now
 
-    ago = "{delta} from now" if future else "{delta} ago"
     seconds = round(td.total_seconds())
+
+    if seconds < 60 and not future:
+        return "now"
+
+    ago = "{delta} from now" if future else "{delta} ago"
+
     years, seconds = divmod(seconds, 60 * 60 * 24 * 365)
     months, seconds = divmod(seconds, 60 * 60 * 24 * 30)
     weeks, seconds = divmod(seconds, 60 * 60 * 24 * 7)
@@ -142,14 +149,7 @@ def natural_time(
         if ret:
             ret += ", "
         ret += f"{hours} {pluralize(hours, 'hour')}"
-    if (
-        minutes
-        and not years
-        and not months
-        and not weeks
-        and not days
-        and not hours
-    ):
+    if minutes and not years and not months and not weeks and not days and not hours:
         if ret:
             ret += ", "
         ret += f"{minutes} {pluralize(minutes, 'minute')}"


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Makes sure pastes younger than a minute are displayed as `Created now...`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
