### PR TITLE
Fix HLJS returning an unusable name with Lang detection.

### DIFF
--- a/web/password.html
+++ b/web/password.html
@@ -17,7 +17,7 @@
 
     <!-- SCRIPTS -->
     <script src="/static/scripts/initialTheme.js?v=1"></script>
-    <script src="/static/scripts/utils.js"></script>
+    <script src="/static/scripts/utils.js?v=2"></script>
     <script src="/static/scripts/themes.js?v=1" defer></script>
     <script src="/static/scripts/hidecopy.js?v=1" defer></script>
     <script src="/static/scripts/highlightsHTMX.js?v=5"></script>

--- a/web/paste.html
+++ b/web/paste.html
@@ -16,7 +16,7 @@
 
     <!-- SCRIPTS -->
     <script src="/static/scripts/initialTheme.js?v=1"></script>
-    <script src="/static/scripts/utils.js"></script>
+    <script src="/static/scripts/utils.js?v=2"></script>
     <script src="/static/scripts/themes.js?v=1" defer></script>
     <script src="/static/scripts/hidecopy.js?v=1" defer></script>
     <script src="/static/scripts/highlights.js?v=5" defer></script>

--- a/web/static/scripts/utils.js
+++ b/web/static/scripts/utils.js
@@ -10,5 +10,7 @@ function getLangByName(name) {
     if (!lang) {
         return null
     }
-    return lang.name;
+
+    let lname = lang.name.replace(/\s+/g, '').toLowerCase();
+    return lname;
 }


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Fixes what appears to be a weird oversight in HLJS.
Changes all names in hljs name detection to lowercase and removes the spaces, which is what HLJS expects when providing a language name.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
